### PR TITLE
Clone points to avoid race condition issues

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          go: [  '1.18',  '1.17',  '1.16',  '1.15', '1.14', '1.13' ]
+          go: [  '1.19', '1.18',  '1.17',  '1.16',  '1.15', '1.14' ]
       name: Go ${{ matrix.go }} sample
       steps:
         - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![CircleCI](https://circleci.com/gh/drand/kyber-bls12381/tree/master.svg?style=shield)](https://circleci.com/gh/drand/drand/tree/master)
-
 # kyber-bls12381
 
 Kyber wrapper around [kilic/bls12381](https://github.com/kilic/bls12-381) library.

--- a/kyber_g1.go
+++ b/kyber_g1.go
@@ -66,16 +66,20 @@ func (k *KyberG1) Data() ([]byte, error) {
 }
 
 func (k *KyberG1) Add(a, b kyber.Point) kyber.Point {
-	aa := a.(*KyberG1)
-	bb := b.(*KyberG1)
-	bls12381.NewG1().Add(k.p, aa.p, bb.p)
+	// we need to clone the point because of https://github.com/kilic/bls12-381/issues/37
+	// in order to avoid risks of race conditions.
+	aa := new(bls12381.PointG1).Set(a.(*KyberG1).p)
+	bb := new(bls12381.PointG1).Set(b.(*KyberG1).p)
+	bls12381.NewG1().Add(k.p, aa, bb)
 	return k
 }
 
 func (k *KyberG1) Sub(a, b kyber.Point) kyber.Point {
-	aa := a.(*KyberG1)
-	bb := b.(*KyberG1)
-	bls12381.NewG1().Sub(k.p, aa.p, bb.p)
+	// we need to clone the point because of https://github.com/kilic/bls12-381/issues/37
+	// in order to avoid risks of race conditions.
+	aa := new(bls12381.PointG1).Set(a.(*KyberG1).p)
+	bb := new(bls12381.PointG1).Set(b.(*KyberG1).p)
+	bls12381.NewG1().Sub(k.p, aa, bb)
 	return k
 }
 
@@ -94,7 +98,10 @@ func (k *KyberG1) Mul(s kyber.Scalar, q kyber.Point) kyber.Point {
 }
 
 func (k *KyberG1) MarshalBinary() ([]byte, error) {
-	return bls12381.NewG1().ToCompressed(k.p), nil
+	// we need to clone the point because of https://github.com/kilic/bls12-381/issues/37
+	// in order to avoid risks of race conditions.
+	t := new(bls12381.PointG1).Set(k.p)
+	return bls12381.NewG1().ToCompressed(t), nil
 }
 
 func (k *KyberG1) UnmarshalBinary(buff []byte) error {

--- a/kyber_g1.go
+++ b/kyber_g1.go
@@ -66,20 +66,16 @@ func (k *KyberG1) Data() ([]byte, error) {
 }
 
 func (k *KyberG1) Add(a, b kyber.Point) kyber.Point {
-	// we need to clone the point because of https://github.com/kilic/bls12-381/issues/37
-	// in order to avoid risks of race conditions.
-	aa := new(bls12381.PointG1).Set(a.(*KyberG1).p)
-	bb := new(bls12381.PointG1).Set(b.(*KyberG1).p)
-	bls12381.NewG1().Add(k.p, aa, bb)
+	aa := a.(*KyberG1)
+	bb := b.(*KyberG1)
+	bls12381.NewG1().Add(k.p, aa.p, bb.p)
 	return k
 }
 
 func (k *KyberG1) Sub(a, b kyber.Point) kyber.Point {
-	// we need to clone the point because of https://github.com/kilic/bls12-381/issues/37
-	// in order to avoid risks of race conditions.
-	aa := new(bls12381.PointG1).Set(a.(*KyberG1).p)
-	bb := new(bls12381.PointG1).Set(b.(*KyberG1).p)
-	bls12381.NewG1().Sub(k.p, aa, bb)
+	aa := a.(*KyberG1)
+	bb := b.(*KyberG1)
+	bls12381.NewG1().Sub(k.p, aa.p, bb.p)
 	return k
 }
 

--- a/kyber_group.go
+++ b/kyber_group.go
@@ -113,15 +113,23 @@ func (s *Suite) GT() kyber.Group {
 // ValidatePairing implements the `pairing.Suite` interface
 func (s *Suite) ValidatePairing(p1, p2, p3, p4 kyber.Point) bool {
 	e := bls12381.NewEngine()
-	e.AddPair(p1.(*KyberG1).p, p2.(*KyberG2).p)
-	e.AddPairInv(p3.(*KyberG1).p, p4.(*KyberG2).p)
+	// we need to clone the point because of https://github.com/kilic/bls12-381/issues/37
+	// in order to avoid risks of race conditions.
+	g1point := new(bls12381.PointG1).Set(p1.(*KyberG1).p)
+	g2point := new(bls12381.PointG2).Set(p2.(*KyberG2).p)
+	g1point2 := new(bls12381.PointG1).Set(p3.(*KyberG1).p)
+	g2point2 := new(bls12381.PointG2).Set(p4.(*KyberG2).p)
+	e.AddPair(g1point, g2point)
+	e.AddPairInv(g1point2, g2point2)
 	return e.Check()
 }
 
 func (s *Suite) Pair(p1, p2 kyber.Point) kyber.Point {
 	e := bls12381.NewEngine()
-	g1point := p1.(*KyberG1).p
-	g2point := p2.(*KyberG2).p
+	// we need to clone the point because of https://github.com/kilic/bls12-381/issues/37
+	// in order to avoid risks of race conditions.
+	g1point := new(bls12381.PointG1).Set(p1.(*KyberG1).p)
+	g2point := new(bls12381.PointG2).Set(p2.(*KyberG2).p)
 	return newKyberGT(e.AddPair(g1point, g2point).Result())
 }
 

--- a/kyber_group.go
+++ b/kyber_group.go
@@ -117,7 +117,7 @@ func (s *Suite) ValidatePairing(p1, p2, p3, p4 kyber.Point) bool {
 	// in order to avoid risks of race conditions.
 	g1point := new(bls12381.PointG1).Set(p1.(*KyberG1).p)
 	g2point := new(bls12381.PointG2).Set(p2.(*KyberG2).p)
-	g1point2 := new(bls12381.PointG1).Set(p3.(*KyberG1).p)
+	g1point2 := p3.(*KyberG1).p
 	g2point2 := new(bls12381.PointG2).Set(p4.(*KyberG2).p)
 	e.AddPair(g1point, g2point)
 	e.AddPairInv(g1point2, g2point2)
@@ -126,10 +126,8 @@ func (s *Suite) ValidatePairing(p1, p2, p3, p4 kyber.Point) bool {
 
 func (s *Suite) Pair(p1, p2 kyber.Point) kyber.Point {
 	e := bls12381.NewEngine()
-	// we need to clone the point because of https://github.com/kilic/bls12-381/issues/37
-	// in order to avoid risks of race conditions.
-	g1point := new(bls12381.PointG1).Set(p1.(*KyberG1).p)
-	g2point := new(bls12381.PointG2).Set(p2.(*KyberG2).p)
+	g1point := p1.(*KyberG1).p
+	g2point := p2.(*KyberG2).p
 	return newKyberGT(e.AddPair(g1point, g2point).Result())
 }
 


### PR DESCRIPTION
Currently, Kilic is modifying the underlying points when calling `Affine`, which can lead to race conditions in drand.

See: https://github.com/kilic/bls12-381/issues/37

This PR clones all possible culprits to avoid race conditions when calling Kilic code.