### PR TITLE
Adding ways to specify a DST in Hash

### DIFF
--- a/kyber_g1.go
+++ b/kyber_g1.go
@@ -28,7 +28,7 @@ type KyberG1 struct {
 	kyber.HashablePoint
 }
 
-func NullKyberG1(dst []byte) *KyberG1 {
+func NullKyberG1(dst ...byte) *KyberG1 {
 	var p bls12381.PointG1
 	return newKyberG1(&p, dst)
 }
@@ -103,7 +103,7 @@ func (k *KyberG1) Neg(a kyber.Point) kyber.Point {
 
 func (k *KyberG1) Mul(s kyber.Scalar, q kyber.Point) kyber.Point {
 	if q == nil {
-		q = NullKyberG1(k.dst).Base()
+		q = NullKyberG1(k.dst...).Base()
 	}
 	bls12381.NewG1().MulScalarBig(k.p, q.(*KyberG1).p, &s.(*mod.Int).V)
 	return k

--- a/kyber_g1.go
+++ b/kyber_g1.go
@@ -30,9 +30,9 @@ type KyberG1 struct {
 
 func NullKyberG1(dst []byte) *KyberG1 {
 	var p bls12381.PointG1
-	return newKyberG1(&p, dst...)
+	return newKyberG1(&p, dst)
 }
-func newKyberG1(p *bls12381.PointG1, dst ...byte) *KyberG1 {
+func newKyberG1(p *bls12381.PointG1, dst []byte) *KyberG1 {
 	return &KyberG1{p: p, dst: dst}
 }
 
@@ -45,11 +45,11 @@ func (k *KyberG1) Equal(k2 kyber.Point) bool {
 }
 
 func (k *KyberG1) Null() kyber.Point {
-	return newKyberG1(bls12381.NewG1().Zero(), k.dst...)
+	return newKyberG1(bls12381.NewG1().Zero(), k.dst)
 }
 
 func (k *KyberG1) Base() kyber.Point {
-	return newKyberG1(bls12381.NewG1().One(), k.dst...)
+	return newKyberG1(bls12381.NewG1().One(), k.dst)
 }
 
 func (k *KyberG1) Pick(rand cipher.Stream) kyber.Point {
@@ -66,7 +66,7 @@ func (k *KyberG1) Set(q kyber.Point) kyber.Point {
 func (k *KyberG1) Clone() kyber.Point {
 	var p bls12381.PointG1
 	p.Set(k.p)
-	return newKyberG1(&p, k.dst...)
+	return newKyberG1(&p, k.dst)
 }
 
 func (k *KyberG1) EmbedLen() int {

--- a/kyber_g1.go
+++ b/kyber_g1.go
@@ -1,6 +1,7 @@
 package bls
 
 import (
+	"bytes"
 	"crypto/cipher"
 	"encoding/hex"
 	"io"
@@ -10,33 +11,48 @@ import (
 	bls12381 "github.com/kilic/bls12-381"
 )
 
+// domainG1 is the DST used for hash to curve on G1, this is the default from the RFC.
+var domainG1 = []byte("BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_")
+
+func DefaultDomainG1() []byte {
+	return domainG1
+}
+
 // KyberG1 is a kyber.Point holding a G1 point on BLS12-381 curve
 type KyberG1 struct {
 	p *bls12381.PointG1
+	// domain separation tag. We treat a 0 len dst as the default value as per the RFC "Tags MUST have nonzero length"
+	dst []byte
+
+	kyber.Point
+	kyber.HashablePoint
 }
 
-func NullKyberG1() *KyberG1 {
+func NullKyberG1(dst []byte) *KyberG1 {
 	var p bls12381.PointG1
-	return newKyberG1(&p)
+	return newKyberG1(&p, dst...)
 }
-func newKyberG1(p *bls12381.PointG1) *KyberG1 {
-	return &KyberG1{p: p}
+func newKyberG1(p *bls12381.PointG1, dst ...byte) *KyberG1 {
+	return &KyberG1{p: p, dst: dst}
 }
 
 func (k *KyberG1) Equal(k2 kyber.Point) bool {
-	return bls12381.NewG1().Equal(k.p, k2.(*KyberG1).p)
+	k2g1, ok := k2.(*KyberG1)
+	if !ok {
+		return false
+	}
+	return bls12381.NewG1().Equal(k.p, k2g1.p) && bytes.Equal(k.dst, k2g1.dst)
 }
 
 func (k *KyberG1) Null() kyber.Point {
-	return newKyberG1(bls12381.NewG1().Zero())
+	return newKyberG1(bls12381.NewG1().Zero(), k.dst...)
 }
 
 func (k *KyberG1) Base() kyber.Point {
-	return newKyberG1(bls12381.NewG1().One())
+	return newKyberG1(bls12381.NewG1().One(), k.dst...)
 }
 
 func (k *KyberG1) Pick(rand cipher.Stream) kyber.Point {
-	//panic("not implemented")
 	var dst, src [32]byte
 	rand.XORKeyStream(dst[:], src[:])
 	return k.Hash(dst[:])
@@ -50,7 +66,7 @@ func (k *KyberG1) Set(q kyber.Point) kyber.Point {
 func (k *KyberG1) Clone() kyber.Point {
 	var p bls12381.PointG1
 	p.Set(k.p)
-	return newKyberG1(&p)
+	return newKyberG1(&p, k.dst...)
 }
 
 func (k *KyberG1) EmbedLen() int {
@@ -87,12 +103,13 @@ func (k *KyberG1) Neg(a kyber.Point) kyber.Point {
 
 func (k *KyberG1) Mul(s kyber.Scalar, q kyber.Point) kyber.Point {
 	if q == nil {
-		q = NullKyberG1().Base()
+		q = NullKyberG1(k.dst).Base()
 	}
 	bls12381.NewG1().MulScalarBig(k.p, q.(*KyberG1).p, &s.(*mod.Int).V)
 	return k
 }
 
+// MarshalBinary returns a compressed point, without any domain separation tag information
 func (k *KyberG1) MarshalBinary() ([]byte, error) {
 	// we need to clone the point because of https://github.com/kilic/bls12-381/issues/37
 	// in order to avoid risks of race conditions.
@@ -100,12 +117,14 @@ func (k *KyberG1) MarshalBinary() ([]byte, error) {
 	return bls12381.NewG1().ToCompressed(t), nil
 }
 
+// UnmarshalBinary populates the point from a compressed point representation.
 func (k *KyberG1) UnmarshalBinary(buff []byte) error {
 	var err error
 	k.p, err = bls12381.NewG1().FromCompressed(buff)
 	return err
 }
 
+// MarshalTo writes a compressed point to the Writer, without any domain separation tag information
 func (k *KyberG1) MarshalTo(w io.Writer) (int, error) {
 	buf, err := k.MarshalBinary()
 	if err != nil {
@@ -114,6 +133,7 @@ func (k *KyberG1) MarshalTo(w io.Writer) (int, error) {
 	return w.Write(buf)
 }
 
+// UnmarshalFrom populates the point from a compressed point representation read from the Reader.
 func (k *KyberG1) UnmarshalFrom(r io.Reader) (int, error) {
 	buf := make([]byte, k.MarshalSize())
 	n, err := io.ReadFull(r, buf)
@@ -133,10 +153,14 @@ func (k *KyberG1) String() string {
 }
 
 func (k *KyberG1) Hash(m []byte) kyber.Point {
-	p, _ := bls12381.NewG1().HashToCurve(m, Domain)
+	domain := domainG1
+	// We treat a 0 len dst as the default value as per the RFC "Tags MUST have nonzero length"
+	if len(k.dst) != 0 {
+		domain = k.dst
+	}
+	p, _ := bls12381.NewG1().HashToCurve(m, domain)
 	k.p = p
 	return k
-
 }
 
 func (k *KyberG1) IsInCorrectGroup() bool {

--- a/kyber_g2.go
+++ b/kyber_g2.go
@@ -26,7 +26,7 @@ type KyberG2 struct {
 	dst []byte
 }
 
-func NullKyberG2(dst []byte) *KyberG2 {
+func NullKyberG2(dst ...byte) *KyberG2 {
 	var p bls12381.PointG2
 	return newKyberG2(&p, dst)
 }
@@ -102,7 +102,7 @@ func (k *KyberG2) Neg(a kyber.Point) kyber.Point {
 
 func (k *KyberG2) Mul(s kyber.Scalar, q kyber.Point) kyber.Point {
 	if q == nil {
-		q = NullKyberG2(k.dst).Base()
+		q = NullKyberG2(k.dst...).Base()
 	}
 	bls12381.NewG2().MulScalarBig(k.p, q.(*KyberG2).p, &s.(*mod.Int).V)
 	return k

--- a/kyber_g2.go
+++ b/kyber_g2.go
@@ -1,8 +1,8 @@
 package bls
 
 import (
+	"bytes"
 	"crypto/cipher"
-	"crypto/sha256"
 	"encoding/hex"
 	"io"
 
@@ -11,34 +11,44 @@ import (
 	bls12381 "github.com/kilic/bls12-381"
 )
 
-// Domain comes from the ciphersuite used by the RFC of this name compatible
-// with the paired library > v18
-var Domain = []byte("BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_")
+// domainG2 is the DST used for hash to curve on G2, this is the default from the RFC.
+// This is compatible with the paired library > v18
+var domainG2 = []byte("BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_")
+
+func DefaultDomainG2() []byte {
+	return domainG2
+}
 
 // KyberG2 is a kyber.Point holding a G2 point on BLS12-381 curve
 type KyberG2 struct {
 	p *bls12381.PointG2
+	// domain separation tag. We treat a 0 len dst as the default value as per the RFC "Tags MUST have nonzero length"
+	dst []byte
 }
 
-func NullKyberG2() *KyberG2 {
+func NullKyberG2(dst []byte) *KyberG2 {
 	var p bls12381.PointG2
-	return newKyberG2(&p)
+	return newKyberG2(&p, dst)
 }
 
-func newKyberG2(p *bls12381.PointG2) *KyberG2 {
-	return &KyberG2{p: p}
+func newKyberG2(p *bls12381.PointG2, dst []byte) *KyberG2 {
+	return &KyberG2{p: p, dst: dst}
 }
 
 func (k *KyberG2) Equal(k2 kyber.Point) bool {
-	return bls12381.NewG2().Equal(k.p, k2.(*KyberG2).p)
+	k2g2, ok := k2.(*KyberG2)
+	if !ok {
+		return false
+	}
+	return bls12381.NewG2().Equal(k.p, k2g2.p) && bytes.Equal(k.dst, k2g2.dst)
 }
 
 func (k *KyberG2) Null() kyber.Point {
-	return newKyberG2(bls12381.NewG2().Zero())
+	return newKyberG2(bls12381.NewG2().Zero(), k.dst)
 }
 
 func (k *KyberG2) Base() kyber.Point {
-	return newKyberG2(bls12381.NewG2().One())
+	return newKyberG2(bls12381.NewG2().One(), k.dst)
 }
 
 func (k *KyberG2) Pick(rand cipher.Stream) kyber.Point {
@@ -55,7 +65,7 @@ func (k *KyberG2) Set(q kyber.Point) kyber.Point {
 func (k *KyberG2) Clone() kyber.Point {
 	var p bls12381.PointG2
 	p.Set(k.p)
-	return newKyberG2(&p)
+	return newKyberG2(&p, k.dst)
 }
 
 func (k *KyberG2) EmbedLen() int {
@@ -92,12 +102,13 @@ func (k *KyberG2) Neg(a kyber.Point) kyber.Point {
 
 func (k *KyberG2) Mul(s kyber.Scalar, q kyber.Point) kyber.Point {
 	if q == nil {
-		q = NullKyberG2().Base()
+		q = NullKyberG2(k.dst).Base()
 	}
 	bls12381.NewG2().MulScalarBig(k.p, q.(*KyberG2).p, &s.(*mod.Int).V)
 	return k
 }
 
+// MarshalBinary returns a compressed point, without any domain separation tag information
 func (k *KyberG2) MarshalBinary() ([]byte, error) {
 	// we need to clone the point because of https://github.com/kilic/bls12-381/issues/37
 	// in order to avoid risks of race conditions.
@@ -105,12 +116,14 @@ func (k *KyberG2) MarshalBinary() ([]byte, error) {
 	return bls12381.NewG2().ToCompressed(t), nil
 }
 
+// UnmarshalBinary populates the point from a compressed point representation.
 func (k *KyberG2) UnmarshalBinary(buff []byte) error {
 	var err error
 	k.p, err = bls12381.NewG2().FromCompressed(buff)
 	return err
 }
 
+// MarshalTo writes a compressed point to the Writer, without any domain separation tag information
 func (k *KyberG2) MarshalTo(w io.Writer) (int, error) {
 	buf, err := k.MarshalBinary()
 	if err != nil {
@@ -119,6 +132,7 @@ func (k *KyberG2) MarshalTo(w io.Writer) (int, error) {
 	return w.Write(buf)
 }
 
+// UnmarshalFrom populates the point from a compressed point representation read from the Reader.
 func (k *KyberG2) UnmarshalFrom(r io.Reader) (int, error) {
 	buf := make([]byte, k.MarshalSize())
 	n, err := io.ReadFull(r, buf)
@@ -138,15 +152,14 @@ func (k *KyberG2) String() string {
 }
 
 func (k *KyberG2) Hash(m []byte) kyber.Point {
-	pg2, _ := bls12381.NewG2().HashToCurve(m, Domain)
+	domain := domainG2
+	// We treat a 0 len dst as the default value as per the RFC "Tags MUST have nonzero length"
+	if len(k.dst) != 0 {
+		domain = k.dst
+	}
+	pg2, _ := bls12381.NewG2().HashToCurve(m, domain)
 	k.p = pg2
 	return k
-}
-
-func sha256Hash(in []byte) []byte {
-	h := sha256.New()
-	h.Write(in)
-	return h.Sum(nil)
 }
 
 func (k *KyberG2) IsInCorrectGroup() bool {

--- a/kyber_group.go
+++ b/kyber_group.go
@@ -97,8 +97,16 @@ type Suite struct {
 	domainG2 []byte
 }
 
+// NewBLS12381Suite is the same as calling NewBLS12381SuiteWithDST(nil, nil): it uses the default domain separation
+// tags for its Hash To Curve functions.
 func NewBLS12381Suite() pairing.Suite {
 	return &Suite{}
+}
+
+// NewBLS12381SuiteWithDST allows you to set your own domain separation tags to be used by the Hash To Curve functions.
+// Since the DST shouldn't be 0 len, if you provide nil or a 0 len byte array, it will use the RFC default values.
+func NewBLS12381SuiteWithDST(DomainG1, DomainG2 []byte) pairing.Suite {
+	return &Suite{domainG1: DomainG1, domainG2: DomainG2}
 }
 
 func (s *Suite) SetDomainG1(dst []byte) {

--- a/kyber_group.go
+++ b/kyber_group.go
@@ -68,18 +68,18 @@ func (g *groupBls) RandomStream() cipher.Stream {
 	return random.New()
 }
 
-func NewGroupG1(dst []byte) kyber.Group {
+func NewGroupG1(dst ...byte) kyber.Group {
 	return &groupBls{
 		str:      "bls12-381.G1",
-		newPoint: func() kyber.Point { return NullKyberG1(dst) },
+		newPoint: func() kyber.Point { return NullKyberG1(dst...) },
 		isPrime:  true,
 	}
 }
 
-func NewGroupG2(dst []byte) kyber.Group {
+func NewGroupG2(dst ...byte) kyber.Group {
 	return &groupBls{
 		str:      "bls12-381.G2",
-		newPoint: func() kyber.Point { return NullKyberG2(dst) },
+		newPoint: func() kyber.Point { return NullKyberG2(dst...) },
 		isPrime:  false,
 	}
 }
@@ -114,7 +114,7 @@ func (s *Suite) SetDomainG1(dst []byte) {
 }
 
 func (s *Suite) G1() kyber.Group {
-	return NewGroupG1(s.domainG1)
+	return NewGroupG1(s.domainG1...)
 }
 
 func (s *Suite) SetDomainG2(dst []byte) {
@@ -122,7 +122,7 @@ func (s *Suite) SetDomainG2(dst []byte) {
 }
 
 func (s *Suite) G2() kyber.Group {
-	return NewGroupG2(s.domainG2)
+	return NewGroupG2(s.domainG2...)
 }
 
 func (s *Suite) GT() kyber.Group {

--- a/kyber_gt.go
+++ b/kyber_gt.go
@@ -27,8 +27,6 @@ func (k *KyberGT) Equal(kk kyber.Point) bool {
 	return k.f.Equal(kk.(*KyberGT).f)
 }
 
-const gtLength = 576
-
 func (k *KyberGT) Null() kyber.Point {
 	// One since we deal with Gt elements as a multiplicative group only
 	// i.e. Add in kyber -> mul in kilic/, Neg in kyber -> inverse in kilic/ etc
@@ -37,17 +35,11 @@ func (k *KyberGT) Null() kyber.Point {
 }
 
 func (k *KyberGT) Base() kyber.Point {
-	panic("not yet available")
-	/*var baseReader, _ = blake2b.NewXOF(0, []byte("Quand il y a à manger pour huit, il y en a bien pour dix."))*/
-	//_, err := NewGT().rand(baseReader)
-	//if err != nil {
-	//panic(err)
-	//}
-	/*return k*/
+	panic("bls12-381.GT.Base(): unsupported operation")
 }
 
 func (k *KyberGT) Pick(rand cipher.Stream) kyber.Point {
-	panic("TODO: bls12-381.GT.Pick()")
+	panic("bls12-381.GT.Pick(): unsupported operation")
 }
 
 func (k *KyberGT) Set(q kyber.Point) kyber.Point {

--- a/kyber_test.go
+++ b/kyber_test.go
@@ -267,11 +267,11 @@ func GroupTest(t *testing.T, g kyber.Group) {
 }
 
 func TestKyberG1(t *testing.T) {
-	GroupTest(t, NewGroupG1(nil))
+	GroupTest(t, NewGroupG1())
 }
 
 func TestKyberG2(t *testing.T) {
-	GroupTest(t, NewGroupG2(nil))
+	GroupTest(t, NewGroupG2())
 }
 
 func TestKyberPairingG2(t *testing.T) {

--- a/kyber_test.go
+++ b/kyber_test.go
@@ -3,6 +3,10 @@ package bls
 import (
 	"bytes"
 	"crypto/cipher"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"github.com/drand/kyber/pairing"
 	"sync"
 	"testing"
 
@@ -263,11 +267,11 @@ func GroupTest(t *testing.T, g kyber.Group) {
 }
 
 func TestKyberG1(t *testing.T) {
-	GroupTest(t, NewGroupG1())
+	GroupTest(t, NewGroupG1(nil))
 }
 
 func TestKyberG2(t *testing.T) {
-	GroupTest(t, NewGroupG2())
+	GroupTest(t, NewGroupG2(nil))
 }
 
 func TestKyberPairingG2(t *testing.T) {
@@ -436,4 +440,72 @@ func TestBasicPairing(t *testing.T) {
 	right = Pair(suite.G1().Point().Base(), suite.G2().Point().Base())
 	right = right.Mul(a, right)
 	require.True(t, left.Equal(right))
+}
+
+func TestVerifySigOnG1WithG2Domain(t *testing.T) {
+	pk := "a0b862a7527fee3a731bcb59280ab6abd62d5c0b6ea03dc4ddf6612fdfc9d01f01c31542541771903475eb1ec6615f8d0df0b8b6dce385811d6dcf8cbefb8759e5e616a3dfd054c928940766d9a5b9db91e3b697e5d70a975181e007f87fca5e"
+	sig := "9544ddce2fdbe8688d6f5b4f98eed5d63eee3902e7e162050ac0f45905a55657714880adabe3c3096b92767d886567d0"
+	round := uint64(1)
+
+	suite := NewBLS12381Suite()
+
+	pkb, _ := hex.DecodeString(pk)
+	pubkeyP := suite.G2().Point()
+	pubkeyP.UnmarshalBinary(pkb)
+	sigb, _ := hex.DecodeString(sig)
+	sigP := suite.G1().Point()
+	sigP.UnmarshalBinary(sigb)
+	h := sha256.New()
+	_ = binary.Write(h, binary.BigEndian, round)
+	msg := h.Sum(nil)
+
+	base := suite.G2().Point().Base().Clone()
+	MsgP := suite.G1().Point().(kyber.HashablePoint).Hash(msg)
+	if suite.ValidatePairing(MsgP, pubkeyP, sigP, base) {
+		t.Fatalf("Should have failed to validate because of invalid domain")
+	}
+
+	// setting the wrong domain for G1 hashing
+	suite.(*Suite).SetDomainG1(DefaultDomainG2())
+	MsgP = suite.G1().Point().(kyber.HashablePoint).Hash(msg)
+	if !suite.ValidatePairing(MsgP, pubkeyP, sigP, base) {
+		t.Fatalf("Error validating pairing")
+	}
+}
+
+func TestVerifySigOnG2(t *testing.T) {
+	pk := "868f005eb8e6e4ca0a47c8a77ceaa5309a47978a7c71bc5cce96366b5d7a569937c529eeda66c7293784a9402801af31"
+	sig := "8d61d9100567de44682506aea1a7a6fa6e5491cd27a0a0ed349ef6910ac5ac20ff7bc3e09d7c046566c9f7f3c6f3b10104990e7cb424998203d8f7de586fb7fa5f60045417a432684f85093b06ca91c769f0e7ca19268375e659c2a2352b4655"
+	prevSig := "176f93498eac9ca337150b46d21dd58673ea4e3581185f869672e59fa4cb390a"
+	round := uint64(1)
+
+	suite := NewBLS12381Suite()
+	pkb, _ := hex.DecodeString(pk)
+	pubkeyP := suite.G1().Point()
+	pubkeyP.UnmarshalBinary(pkb)
+	sigb, _ := hex.DecodeString(sig)
+	sigP := suite.G2().Point()
+	sigP.UnmarshalBinary(sigb)
+	prev, _ := hex.DecodeString(prevSig)
+	h := sha256.New()
+	h.Write(prev)
+	_ = binary.Write(h, binary.BigEndian, round)
+	msg := h.Sum(nil)
+
+	base := suite.G1().Point().Base().Clone()
+	MsgP := suite.G2().Point().(kyber.HashablePoint).Hash(msg)
+	if !suite.ValidatePairing(base, sigP, pubkeyP, MsgP) {
+		t.Fatalf("Error validating pairing")
+	}
+}
+
+func TestImplementInterfaces(t *testing.T) {
+	var _ kyber.Point = &KyberG1{}
+	var _ kyber.Point = &KyberG2{}
+	var _ kyber.Point = &KyberGT{}
+	var _ kyber.HashablePoint = &KyberG1{}
+	var _ kyber.HashablePoint = &KyberG2{}
+	// var _ kyber.HashablePoint = &KyberGT{} // GT is not hashable for now
+	var _ kyber.Group = &groupBls{}
+	var _ pairing.Suite = &Suite{}
 }

--- a/tests/consumer/consume.go
+++ b/tests/consumer/consume.go
@@ -21,6 +21,7 @@ type testVector struct {
 }
 
 func main() {
+	retCount := 0
 	fname := os.Args[1]
 	f, err := os.Open(fname)
 	if err != nil {
@@ -32,22 +33,23 @@ func main() {
 		panic(err)
 	}
 	for i, tv := range tests {
-		bls.Domain = []byte(tv.Ciphersuite)
-		g1 := bls.NullKyberG1().Hash([]byte(tv.Msg))
+		g1 := bls.NullKyberG1([]byte(tv.Ciphersuite)).Hash([]byte(tv.Msg))
 		g1Buff, _ := g1.MarshalBinary()
 		exp := tv.G1Compressed
 		if !bytes.Equal(g1Buff, exp) {
+			retCount++
 			fmt.Println("test", i, " fails at G1")
 		}
-		g2 := bls.NullKyberG2().Hash([]byte(tv.Msg))
+		g2 := bls.NullKyberG2([]byte(tv.Ciphersuite)).Hash([]byte(tv.Msg))
 		g2Buff, _ := g2.MarshalBinary()
 		exp = tv.G2Compressed
 		if !bytes.Equal(g2Buff, exp) {
+			retCount++
 			fmt.Println("test", i, " fails at G2")
 		}
 
 		if tv.BLSPrivKey != "" {
-			// SIGNATURE is always happening on bls.Domain
+			// SIGNATURE is always happening on bls.DomainG2
 			pairing := bls.NewBLS12381Suite()
 			scheme := sig.NewSchemeOnG2(pairing)
 			pubKey := pairing.G1().Point()
@@ -56,8 +58,10 @@ func main() {
 			}
 			err := scheme.Verify(pubKey, []byte(tv.Msg), tv.BLSSigG2)
 			if err != nil {
+				retCount++
 				fmt.Println("test", i, " fails for signature")
 			}
 		}
 	}
+	os.Exit(retCount)
 }

--- a/tests/consumer/consume.go
+++ b/tests/consumer/consume.go
@@ -33,14 +33,14 @@ func main() {
 		panic(err)
 	}
 	for i, tv := range tests {
-		g1 := bls.NullKyberG1([]byte(tv.Ciphersuite)).Hash([]byte(tv.Msg))
+		g1 := bls.NullKyberG1([]byte(tv.Ciphersuite)...).Hash([]byte(tv.Msg))
 		g1Buff, _ := g1.MarshalBinary()
 		exp := tv.G1Compressed
 		if !bytes.Equal(g1Buff, exp) {
 			retCount++
 			fmt.Println("test", i, " fails at G1")
 		}
-		g2 := bls.NullKyberG2([]byte(tv.Ciphersuite)).Hash([]byte(tv.Msg))
+		g2 := bls.NullKyberG2([]byte(tv.Ciphersuite)...).Hash([]byte(tv.Msg))
 		g2Buff, _ := g2.MarshalBinary()
 		exp = tv.G2Compressed
 		if !bytes.Equal(g2Buff, exp) {

--- a/tests/generator/compatibility.dat
+++ b/tests/generator/compatibility.dat
@@ -2,8 +2,17 @@
     {
         "Msg": "",
         "Ciphersuite": "",
-        "G1Compressed": "iMfjiO5Y8duaJNcJiwHRNjQpi+vy0VklSXW9RQyw0of8xiLrce3ei0aahRNVG68f",
-        "G2Compressed": "tpMntJx8f85XL+S+CDcW+K1dHJhsRBIOgcnGwDb9RkhF/iTtOM/Ok9D0ZHcZ8bteAXh8hH3vRZLMVGVsAzKPLO9i2oUrbNYcy6FEfpTGqXJSeEh/KPPHGfJOKY6eCTqj",
+        "G1Compressed": "suDmYhgb2fjNjvJGBxNXzQeiPEOR6Hm0njIITcwaKu3hI8jov83pLtrCKeKLcZFC",
+        "G2Compressed": "qKqzA+M+0U9KkEAEqSvSb/yWnB0efUt/DAQVCnPhhFqRHlGistNp1c7wZWDFrJ9XFcAVZpk9RGmAXfPh8ptTZIGoMr8nUbaQj67Wd20GLVhVIYiSMpmdcrZ51uOLtc//",
+        "BLSPrivKey": "",
+        "BLSPubKey": null,
+        "BLSSigG2": null
+    },
+    {
+        "Msg": "",
+        "Ciphersuite": "BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_",
+        "G1Compressed": "suDmYhgb2fjNjvJGBxNXzQeiPEOR6Hm0njIITcwaKu3hI8jov83pLtrCKeKLcZFC",
+        "G2Compressed": "t8Ej55+N2eHVxM9vIK6UNyKnJ8alAlIFd1sHcJvWWy1t41cf/xggBL8V79kC0Y6oGAyyqOtMydO3QK9+kSyWGvi9etkTSKK1ZtvJB6WcS5nY+6NiVs2fSm3xwlI2WDfS",
         "BLSPrivKey": "",
         "BLSPubKey": null,
         "BLSSigG2": null
@@ -13,9 +22,18 @@
         "Ciphersuite": "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_",
         "G1Compressed": "hMW6jNJQe93jbkaX0CfwuJUHmHHFh+7DY819un+7BfxKvHjAFQ9Glqr4jhBDqXPD",
         "G2Compressed": "qKqzA+M+0U9KkEAEqSvSb/yWnB0efUt/DAQVCnPhhFqRHlGistNp1c7wZWDFrJ9XFcAVZpk9RGmAXfPh8ptTZIGoMr8nUbaQj67Wd20GLVhVIYiSMpmdcrZ51uOLtc//",
-        "BLSPrivKey": "27539689655622540958679105641905086851274830069992722298279813327323206776590",
-        "BLSPubKey": "sr4R3I5U7nTbwHVp/XT+A7X1Ktcc1JqFebbGOHiR9aIK2YDsJ0dhjBua01hGpoo+",
-        "BLSSigG2": "tTz9+LSIoobfHtIEMuK7xOY2EAN1ff2jpP1s2Y3pXlUT98RI1wsmgeFFR6bO1H58EOKEMuiryzTeHcKPOTKP0qE9sSpMajC9F7DkKIGkKQA+TCRYO6DymkD9g2zwXhpA"
+        "BLSPrivKey": "47513352334474430269451736385780177621351802298989911096234326721557800710527",
+        "BLSPubKey": "hN6zagqRrc7xpA9reh09Bp9tf86945S7idxCpfz+nmiMjQbzNvK2OGzq3Z6eVS4q",
+        "BLSSigG2": "laAlM+Vub9FJC6I09lnkPsmYZLBqDfK0HNaXEoRu0uSGYO2g0SsLV3PbwX+nma+kAWAKfhWw5fHeOV+HNC4tcTVkE3dQmHJq4t4A7AWXRuUlSZjLkNUDIT4vZdfhYcFf"
+    },
+    {
+        "Msg": "1234",
+        "Ciphersuite": "BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_",
+        "G1Compressed": "sDSo0qRtu8ypPyznwH3+Pyh82WkwuDEWe6tpSiqCMpGRKYeKnzOkj4xXcEId+MNY",
+        "G2Compressed": "j6hZpRTryvO7mhDDXO+iwRplDeCLZMQirDMs1m90ql3kpPx8+LfLnoe3wIynP1LeFuLRbi6VqIr/g7x8BoT5tPRG4KPi1B8T78gYQ69IeZoLwYjd3SZz+JAheadBU9mq",
+        "BLSPrivKey": "",
+        "BLSPubKey": null,
+        "BLSSigG2": null
     },
     {
         "Msg": "1234",

--- a/tests/generator/generate.go
+++ b/tests/generator/generate.go
@@ -56,9 +56,9 @@ func main() {
 	tvs = fill(tvs)
 	for _, tv := range tvs {
 		Domain := []byte(tv.cipher)
-		g1 := bls.NullKyberG1(Domain).Hash([]byte(tv.msg))
+		g1 := bls.NullKyberG1(Domain...).Hash([]byte(tv.msg))
 		g1Buff, _ := g1.MarshalBinary()
-		g2 := bls.NullKyberG2(Domain).Hash([]byte(tv.msg))
+		g2 := bls.NullKyberG2(Domain...).Hash([]byte(tv.msg))
 		g2Buff, _ := g2.MarshalBinary()
 		s := toWrite{
 			Msg:          tv.msg,

--- a/tests/generator/generate.go
+++ b/tests/generator/generate.go
@@ -39,19 +39,26 @@ func main() {
 		},
 		{
 			msg:    "",
-			cipher: string(bls.Domain),
+			cipher: string(bls.DefaultDomainG1()),
+		},
+		{
+			msg:    "",
+			cipher: string(bls.DefaultDomainG2()),
 		},
 		{
 			msg:    "1234",
-			cipher: string(bls.Domain),
+			cipher: string(bls.DefaultDomainG1()),
+		}, {
+			msg:    "1234",
+			cipher: string(bls.DefaultDomainG2()),
 		},
 	}
 	tvs = fill(tvs)
 	for _, tv := range tvs {
-		bls.Domain = []byte(tv.cipher)
-		g1 := bls.NullKyberG1().Hash([]byte(tv.msg))
+		Domain := []byte(tv.cipher)
+		g1 := bls.NullKyberG1(Domain).Hash([]byte(tv.msg))
 		g1Buff, _ := g1.MarshalBinary()
-		g2 := bls.NullKyberG2().Hash([]byte(tv.msg))
+		g2 := bls.NullKyberG2(Domain).Hash([]byte(tv.msg))
 		g2Buff, _ := g2.MarshalBinary()
 		s := toWrite{
 			Msg:          tv.msg,
@@ -60,8 +67,8 @@ func main() {
 			G2Compressed: g2Buff,
 		}
 
-		if bytes.Equal([]byte(tv.cipher), bls.Domain) {
-			// SIGNATURE is always happening on bls.Domain
+		if bytes.Equal([]byte(tv.cipher), bls.DefaultDomainG2()) {
+			// SIGNATURE is always happening on bls.DomainG2
 			pairing := bls.NewBLS12381Suite()
 			scheme := sig.NewSchemeOnG2(pairing)
 			priv, pub := scheme.NewKeyPair(random.New())
@@ -92,18 +99,18 @@ func main() {
 func fill(tvs []testVector) []testVector {
 	tvs = append(tvs, testVector{
 		msg:    randomString(32),
-		cipher: string(bls.Domain),
+		cipher: string(bls.DefaultDomainG2()),
 	})
 	tvs = append(tvs, testVector{
 		msg:    randomString(64),
-		cipher: string(bls.Domain),
+		cipher: string(bls.DefaultDomainG2()),
 	})
 	for i := 0; i < 100; i++ {
 		msgLen := mrand.Intn(2000)
 		msg := randomString(msgLen)
 		tvs = append(tvs, testVector{
 			msg:    msg,
-			cipher: string(bls.Domain),
+			cipher: string(bls.DefaultDomainG2()),
 		})
 	}
 	return tvs


### PR DESCRIPTION
This is meant to be a v0.3.0, breaking a few public API as little as possible.

It adds the capability to set different Domain Separation Tags for each group G1 and G2.