### PR TITLE
Default DST values are represented as `nil` internally

### DIFF
--- a/kyber_g1.go
+++ b/kyber_g1.go
@@ -33,7 +33,11 @@ func NullKyberG1(dst ...byte) *KyberG1 {
 	return newKyberG1(&p, dst)
 }
 func newKyberG1(p *bls12381.PointG1, dst []byte) *KyberG1 {
-	return &KyberG1{p: p, dst: dst}
+	domain := dst
+	if bytes.Equal(dst, domainG1) {
+		domain = nil
+	}
+	return &KyberG1{p: p, dst: domain}
 }
 
 func (k *KyberG1) Equal(k2 kyber.Point) bool {

--- a/kyber_g2.go
+++ b/kyber_g2.go
@@ -32,7 +32,11 @@ func NullKyberG2(dst ...byte) *KyberG2 {
 }
 
 func newKyberG2(p *bls12381.PointG2, dst []byte) *KyberG2 {
-	return &KyberG2{p: p, dst: dst}
+	domain := dst
+	if bytes.Equal(dst, domainG2) {
+		domain = nil
+	}
+	return &KyberG2{p: p, dst: domain}
 }
 
 func (k *KyberG2) Equal(k2 kyber.Point) bool {


### PR DESCRIPTION
This allows us to save some memory when using the default values.

I've also added an explicit test for this usecase. That will make my remark in https://github.com/drand/drand/pull/1249 irrelevant from a perf pov.

I'll release a v0.3.1 with this change if it's merged before we merge the drand changes